### PR TITLE
change socket.io to websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ module.exports = [
 
 ### Real time
 
-Websockets were never this easy to use! With socket.io on the front-end, you can simply do this in the back-end to handle those events:
+Websockets were never this easy to use! You can simply use `router.socket` in the back-end to handle those events:
 
 ```js
 // chat/router.js

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "response-time": "^2.3.2",
     "serve-favicon": "^2.3.2",
     "serve-index": "^1.8.0",
-    "socket.io": "^2.0.3"
+    "ws": "^3.3.0"
   },
   "devDependencies": {
     "eslint": "^4.7.2",


### PR DESCRIPTION
socket.io is really slow and requires that you load a bunch of js on the client side. `window.WebSocket` is fast and actually has a simpler api, which i feel would better fall in line with this library and remain agnostic.