### PR TITLE
Use `or` instead of `and` as options

### DIFF
--- a/docs/documentation/options/README.md
+++ b/docs/documentation/options/README.md
@@ -342,7 +342,7 @@ You can also set the function to `async` and it will wait until it is resolved, 
 |------|--------------|---------------------------|---------------|---------------------|
 |`env` |`development` |**`NODE_ENV=development`** |String, Object |['development', 'test', 'production']  |
 
-Define the context in which the server is running. It **has to be** one of these: `'development'`, `'test'` and `'production'`. Some functionality might vary depending on the environment, such as live/hot reloading, cache, etc. so it is recommended that you set these appropriately.
+Define the context in which the server is running. It **has to be** one of these: `'development'`, `'test'` or `'production'`. Some functionality might vary depending on the environment, such as live/hot reloading, cache, etc. so it is recommended that you set these appropriately.
 
 > Note: The environment variable is called **NODE_ENV** while the option as a parameter is **env**.
 

--- a/docs/documentation/options/index.html
+++ b/docs/documentation/options/index.html
@@ -350,7 +350,7 @@ server(options, [
 </tr>
 </tbody>
 </table>
-<p>Define the context in which the server is running. It <strong>has to be</strong> one of these: <code>&#39;development&#39;</code>, <code>&#39;test&#39;</code> and <code>&#39;production&#39;</code>. Some functionality might vary depending on the environment, such as live/hot reloading, cache, etc. so it is recommended that you set these appropriately.</p>
+<p>Define the context in which the server is running. It <strong>has to be</strong> one of these: <code>&#39;development&#39;</code>, <code>&#39;test&#39;</code> or <code>&#39;production&#39;</code>. Some functionality might vary depending on the environment, such as live/hot reloading, cache, etc. so it is recommended that you set these appropriately.</p>
 <blockquote>
 <p>Note: The environment variable is called <strong>NODE_ENV</strong> while the option as a parameter is <strong>env</strong>.</p>
 </blockquote>


### PR DESCRIPTION
Reads better if we provide options as one, two, or three instead of one,
two, and three.