### PR TITLE
Allow disabling public

### DIFF
--- a/plugins/static/index.js
+++ b/plugins/static/index.js
@@ -11,8 +11,7 @@ module.exports = {
     }
   },
   init: ctx => {
-    module.exports.before = [
-      modern(ctx.express.static(ctx.options.static.public))
-    ];
+    module.exports.before = ctx.options.static.public ?
+      [modern(ctx.express.static(ctx.options.static.public))] : [];
   }
 };

--- a/plugins/static/unit.test.js
+++ b/plugins/static/unit.test.js
@@ -24,4 +24,9 @@ describe('static plugin', () => {
     expect(res.statusCode).toBe(404);
     expect(out.log).toMatch(/did not return anything/);
   });
+  
+  it('does not serve if set to false', async () => {
+    const res = await run({ public: false }).get('/logo.png');
+    expect(res.statusCode).toBe(404);
+  });
 });


### PR DESCRIPTION
**Describe the bug**
For now public option defaults to 'public'. There's a section in the docs to disable public, but it doesn't work as intended:
- `public: false` will produce error on starting server (UnhandledPromiseRejectionWarning: TypeError: root path required)
- `public: ''` will actually makes the root directory of application all public, which is really dangerous

**To Reproduce**
Steps to reproduce the behavior:
1. install server `npm i server`
2. setup simple index.js with `{public: false}` or `{public: ''}` as the server option
3. the bug will reproduce as written above

**Expected behavior**
- `public: false` and `public: ''` should not give error and should not serve static files
