### PR TITLE
Fixed 132 by making sure the routers send the reply

### DIFF
--- a/examples/bug132/index.js
+++ b/examples/bug132/index.js
@@ -1,0 +1,6 @@
+const server = require('../../');
+
+const { get } = server.router;
+const { status } = server.reply;
+
+server([get(ctx => status(404))]);

--- a/router/generic.js
+++ b/router/generic.js
@@ -30,5 +30,8 @@ module.exports = (method, ...all) => {
     await join(middle)(ctx);
 
     ctx.req.solved = true;
+    if (!ctx.res.headersSent) {
+      ctx.res.end();
+    }
   };
 };

--- a/router/sub.js
+++ b/router/sub.js
@@ -6,5 +6,8 @@ module.exports = (path, ...middle) => async ctx => {
       (path instanceof RegExp && path.test(full))) {
     await join(middle)(ctx);
     ctx.req.solved = true;
+    if (!ctx.res.headersSent) {
+      ctx.res.end();
+    }
   }
 };

--- a/router/unit.test.js
+++ b/router/unit.test.js
@@ -9,7 +9,7 @@ const run = require('server/test/run');
 
 const createCtx = ({ url = '/', path = '/', method = 'GET' } = {}) => extend({
   req: { url, path, method },
-  res: { send: () => {} },
+  res: { send: () => {}, end: () => {} },
   options: {}
 });
 


### PR DESCRIPTION
The [`join()`](https://github.com/franciscop/server/blob/master/src/join/index.js#L22) method [skips any subsequent middleware](https://github.com/franciscop/server/blob/master/src/join/index.js#L31) if any middleware marks the request as `solved`, but in the case of a router it could happen that a route was marked as solved but was not fully sent. Fixed that for both the general methods (`get`/`post`/`put`/`del`) and for `sub()` as well.