### PR TITLE
Added "cors" to list of socket options

### DIFF
--- a/plugins/socket/index.js
+++ b/plugins/socket/index.js
@@ -25,7 +25,8 @@ module.exports = {
     cookie: {},
     cookiePath: {},
     cookieHttpOnly: {},
-    wsEngine: {}
+    wsEngine: {},
+    cors: {},
   },
   router: (path, middle) => {
     listeners[path] = listeners[path] || [];


### PR DESCRIPTION
We need to be able to pass cors options to the socket.io instance:

```
server(
  {
    port,
    socket: {
      cors: {
        origin: "http://localhost:3000",
        methods: ["GET", "POST"],
        allowedHeaders: ["Content-Type"],
        credentials: true,
      },
    },
  },
  cors,
  [
    get("/", (ctx) => render("index.html")),
    socket("connect", updateCounter),
    socket("disconnect", updateCounter),
    socket("message", sendMessage),
  ]
);
```